### PR TITLE
DEV-771 Is-valid check regardless of eventOutcome

### DIFF
--- a/app/helpers/events_parser.py
+++ b/app/helpers/events_parser.py
@@ -71,12 +71,10 @@ class PremisEvent:
     def _is_valid(self):
         """A PremisEvent is valid only if:
             - it has a valid eventType for this particular application,
-            - if it has a fragment ID,
-            - if it's eventOutcome is 'OK'.
+            - if it has a fragment ID.
         """
         if (self.event_type in VALID_EVENT_TYPES and
-            self.fragment_id and
-            self.event_outcome == 'OK'):
+            self.fragment_id):
             return True
         return False
 

--- a/tests/helpers/test_events_parser.py
+++ b/tests/helpers/test_events_parser.py
@@ -24,7 +24,7 @@ def test_single_event():
     assert p.events[0].event_detail == "Ionic Defibulizer"
     assert p.events[0].fragment_id == "a1b2c3"
     assert p.events[0].event_type == "FLOW.ARCHIVED"
-    assert p.events[0].event_outcome == "OK"
+    assert p.events[0].event_outcome == "NOK"
     assert p.events[0].is_valid
 
 def test_multi_event():

--- a/tests/resources/single_premis_event.xml
+++ b/tests/resources/single_premis_event.xml
@@ -9,7 +9,7 @@
     <premis:eventDateTime>2019-03-30T05:28:40Z</premis:eventDateTime>
     <premis:eventDetail>Ionic Defibulizer</premis:eventDetail>
     <premis:eventOutcomeInformation>
-      <premis:eventOutcome>OK</premis:eventOutcome>
+      <premis:eventOutcome>NOK</premis:eventOutcome>
     </premis:eventOutcomeInformation>
     <premis:linkingAgentIdentifier>
       <premis:linkingAgentIdentifierType>MEDIAHAVEN_USER</premis:linkingAgentIdentifierType>


### PR DESCRIPTION
The check if a PremisEvent is valid should not be dependent of the
value of the 'eventOutcome' XML tag.