### PR TITLE
DEV-884 Allow routing via exchange and routing key

### DIFF
--- a/tests/services/pika_mock.py
+++ b/tests/services/pika_mock.py
@@ -6,12 +6,15 @@ class Channel:
     """Mocks a pika Channel"""
 
     def __init__(self):
+        self.exchanges = {}
         self.queues = {}
 
     def basic_publish(self, *args, **kwargs):
-        """Puts a message on the in-memory list"""
+        """Puts a message on the in-memory list via the exchange"""
 
-        self.queues[kwargs["routing_key"]].append(kwargs["body"])
+        exchange = kwargs["exchange"]
+        routing_key = kwargs["routing_key"]
+        self.exchanges[exchange][routing_key].append(kwargs["body"])
 
     def queue_declare(self, *args, **kwargs):
         """Creates an in-memory list to act as queue"""
@@ -19,6 +22,20 @@ class Channel:
         queue = kwargs["queue"]
         if not self.queues.get(queue):
             self.queues[queue] = []
+
+    def exchange_declare(self, *args, **kwargs):
+        """Create an in memory dict to act as an exchange"""
+
+        exchanges = kwargs["exchange"]
+        if not self.exchanges.get(exchanges):
+            self.exchanges[exchanges] = {}
+
+    def queue_bind(self, *args, **kwargs):
+        """Map the queue to the exchange"""
+
+        exchange = kwargs["exchange"]
+        queue = kwargs["queue"]
+        self.exchanges[exchange][queue] = self.queues[queue]
 
 
 class Connection:

--- a/tests/services/test_rabbit_service.py
+++ b/tests/services/test_rabbit_service.py
@@ -15,6 +15,7 @@ class TestRabbitService:
             "rabbit": {
                 "host": "localhost",
                 "queue": "archived",
+                "exchange": "exchange",
                 "username": "guest",
                 "password": "guest"
             }
@@ -32,7 +33,8 @@ class TestRabbitService:
         conn_mock.return_value = pika_conn
 
         rabbit_service.publish_message('message')
-        messages = pika_conn.channel_mock.queues["archived"]
+        exchange = pika_conn.channel_mock.exchanges["exchange"]
+        messages = exchange["archived"]
         assert len(messages) == 1
         assert messages[0] == 'message'
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -105,6 +105,7 @@ def test_handle_event(config_mock, post_event_mock, get_fragment_metadata_mock, 
             "rabbit": {
                 "host": "localhost",
                 "queue": "archived",
+                "exchange": "exchange",
                 "username": "guest",
                 "password": "guest"
             }
@@ -128,8 +129,8 @@ def test_handle_event(config_mock, post_event_mock, get_fragment_metadata_mock, 
     # Mocked publish to RabbitMQ queue
     basic_publish = conn_mock().channel.return_value.basic_publish.call_args[1]
 
-    # Check if message is being sent to direct queue
-    assert basic_publish["exchange"] == ""
+    # Check if message is being sent via routing
+    assert basic_publish["exchange"] == "exchange"
     assert basic_publish["routing_key"] == "archived"
 
     # Check if the actual XML message sent to the queue is correct


### PR DESCRIPTION
A key `exchange` is now expected in the config file. The value of the
key `queue` in the config file is also being used as the routing key.