### PR TITLE
DEV-882 Improve handling response of call to MH

### DIFF
--- a/app/services/mediahaven_service.py
+++ b/app/services/mediahaven_service.py
@@ -8,6 +8,11 @@ import requests
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import RequestException
 
+class MediaObjectNotFoundException(Exception):
+    """Exception raised when MediaHaven doesn't find a media object given the ID."""
+
+    pass
+
 
 class AuthenticationException(Exception):
     """Exception raised when authentication fails."""
@@ -70,5 +75,8 @@ class MediahavenService:
         if response.status_code == 401:
             # AuthenticationException triggers a retry with a new token
             raise AuthenticationException(response.text)
+
+        if response.status_code in (400, 404):
+            raise MediaObjectNotFoundException(response.json())
 
         return response.json()

--- a/tests/services/test_mediahaven_service.py
+++ b/tests/services/test_mediahaven_service.py
@@ -1,16 +1,25 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 from unittest.mock import patch, MagicMock
 
-from app.services.mediahaven_service import MediahavenService
+import pytest
+
+from app.services.mediahaven_service import (
+    MediahavenService,
+    MediaObjectNotFoundException
+)
 
 
 class TestMediahavenService:
-    @patch("app.services.mediahaven_service.requests")
+
+    @pytest.fixture
     @patch.object(
         MediahavenService,
         "_MediahavenService__get_token",
         return_value={"access_token": "Bear with me"},
     )
-    def test_get_fragment(self, mhs_get_token_mock, get_media_mock):
+    def mediahaven_service(self, mhs_get_token_mock):
         mh_config_dict = {
             "environment": {
                 "mediahaven": {
@@ -21,14 +30,20 @@ class TestMediahavenService:
             }
         }
 
+        mhs = MediahavenService(mh_config_dict)
+        # Patch out __get_token so it doesn't send a request to MediaHaven
+        mhs._MediahavenService__get_token = mhs_get_token_mock
+        return mhs
+
+    @patch("app.services.mediahaven_service.requests")
+    def test_get_fragment(self, get_media_mock, mediahaven_service):
         # Mock response data
         response_mock = MagicMock()
         response_mock.json.return_value = '{"key": "value"}'
         response_mock.status_code = 200
         get_media_mock.get.return_value = response_mock
 
-        mhs = MediahavenService(mh_config_dict)
-        mhs.get_fragment("1")
+        result = mediahaven_service.get_fragment("1")
 
         assert get_media_mock.get.call_count == 1
         assert get_media_mock.get.call_args[0][0] == "mediahaven/media/1"
@@ -40,3 +55,50 @@ class TestMediahavenService:
             get_media_mock.get.call_args[1]["headers"]["Accept"]
             == "application/vnd.mediahaven.v2+json"
         )
+        assert result == '{"key": "value"}'
+
+    @patch("app.services.mediahaven_service.requests")
+    def test_get_fragment_response_400(self, get_media_mock, mediahaven_service):
+        # Construct response message
+        status = 400
+        code = "EPARAMINV"
+        message = "No correct MediaObjectId or FragmentId specified"
+        response = {
+            "status": status,
+            "message": message,
+            "code": code,
+        }
+
+        # Mock response data
+        response_mock = MagicMock()
+        response_mock.json.return_value = response
+        response_mock.status_code = status
+        get_media_mock.get.return_value = response_mock
+
+        with pytest.raises(MediaObjectNotFoundException) as error:
+            mediahaven_service.get_fragment("1")
+        assert error.value.args[0] == response
+
+    @patch("app.services.mediahaven_service.requests")
+    def test_get_fragment_response_404(self, get_media_mock, mediahaven_service):
+        # Construct response message
+        status = 404
+        code = "EPARAMINV"
+        fragment_id = "1"
+        message = f"The object with fragmentId: {fragment_id} could not be found"
+        response = {
+            "status": status,
+            "message": message,
+            "code": code,
+            "fragmentId": fragment_id,
+        }
+
+        # Mock response data
+        response_mock = MagicMock()
+        response_mock.json.return_value = response
+        response_mock.status_code = status
+        get_media_mock.get.return_value = response_mock
+
+        with pytest.raises(MediaObjectNotFoundException) as error:
+            mediahaven_service.get_fragment("1")
+        assert error.value.args[0] == response

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -18,6 +18,7 @@ from app.app import (
 )
 from tests.resources import single_premis_event
 from app.helpers.events_parser import InvalidPremisEventException, PremisEvents
+from app.services.mediahaven_service import MediaObjectNotFoundException
 
 
 def _create_fragment_info_dict(pid: str, md5: str, s3_object_key: str, s3_bucket: str):
@@ -94,6 +95,29 @@ def test_get_fragment_metadata(mhs_mock):
     assert metadata["md5"] == "md5"
 
 
+@patch('app.app.MediahavenService')
+def test_get_fragment_metadata_key_not_found(mhs_mock):
+    # Mock call to MediaHaven to return insufficient information
+    get_fragment_result = {
+        "Administrative": {
+            "ExternalId": "pid"
+        }
+    }
+    mhs_mock.return_value.get_fragment.return_value = get_fragment_result
+
+    metadata = get_fragment_metadata('fragment_id')
+    assert metadata == {}
+
+
+@patch('app.app.MediahavenService')
+def test_get_fragment_metadata_media_not_found(mhs_mock):
+    # Mock call to MediaHaven to raise A MediaObjectNotFoundException
+    mhs_mock.return_value.get_fragment.side_effect = MediaObjectNotFoundException("denied")
+    
+    metadata = get_fragment_metadata('fragment_id')
+    assert metadata == {}
+
+
 @patch('pika.BlockingConnection')
 @patch('app.app.get_fragment_metadata')
 @patch('app.app.request')
@@ -145,7 +169,7 @@ def test_handle_event(config_mock, post_event_mock, get_fragment_metadata_mock, 
     assert tree.xpath('/m:essenceArchivedEvent/m:s3bucket/text()', namespaces=ns)[0] == "s3_bucket"
     assert tree.xpath('/m:essenceArchivedEvent/m:md5sum/text()', namespaces=ns)[0] == "md5"
     assert tree.xpath('/m:essenceArchivedEvent/m:timestamp/text()', namespaces=ns)[0] == "2019-03-30T05:28:40Z"
-    result == ("OK", status.HTTP_200_OK)
+    assert result == ("OK", status.HTTP_200_OK)
 
 
 @patch('app.app.request')
@@ -155,7 +179,7 @@ def test_handle_event_xml_error(premis_events_mock, post_event_mock,):
     post_event_mock.data = ''
 
     result = handle_event()
-    result[1] == status.HTTP_400_BAD_REQUEST
+    assert result[1] == status.HTTP_400_BAD_REQUEST
 
 
 @patch('app.app.request')
@@ -165,4 +189,21 @@ def test_handle_event_invalid_premis_event(premis_events_mock, post_event_mock):
     post_event_mock.data = ''
 
     result = handle_event()
-    result[1] == status.HTTP_400_BAD_REQUEST
+    assert result[1] == status.HTTP_400_BAD_REQUEST
+
+
+@patch('pika.BlockingConnection')
+@patch('app.app.get_fragment_metadata')
+@patch('app.app.request')
+def test_handle_event_empty_fragment(post_event_mock, get_fragment_metadata_mock, conn_mock):
+    # Mock request.data to return a single premis event
+    post_event_mock.data = single_premis_event
+    # Mock get_fragment_metadata() to return an empty-dict
+    get_fragment_metadata_mock.return_value = {}
+
+    result = handle_event()
+
+    # Check if there is no message been sent to the queue
+    assert conn_mock().call_count == 0
+    # Should still return "200"
+    assert result == ("OK", status.HTTP_200_OK)


### PR DESCRIPTION
- When the response of the call to MediaHaven indicates that it could
  not find a media object for the ID coming in via the webhook, it will
  log an error. No essence-archived XML will be send out to the queue.
- When the response does not have the desired format, it will not send
  an empty essence-archived message out to the queue anymore.

Other:

- Assert valid result in TestMediahavenService.test_get_fragment().
- Fix the handle_event tests to actually assert the response.
- Add shebang in test_mediahaven_service.py.
- Change comment about is_valid in handle_event() to be more precise.