### PR TITLE
DEV-907 Absence of external ID in premis event

### DIFF
--- a/app/helpers/events_parser.py
+++ b/app/helpers/events_parser.py
@@ -18,56 +18,32 @@ class InvalidPremisEventException(Exception):
 class PremisEvent:
     """Convenience class for a single XML Premis Event"""
 
+    XPATHS = {
+        "event_type": "./p:eventType",
+        "event_datetime":"./p:eventDateTime",
+        "event_detail": "./p:eventDetail",
+        "event_id": "./p:eventIdentifier[p:eventIdentifierType='MEDIAHAVEN_EVENT']/p:eventIdentifierValue",
+        "event_outcome": "./p:eventOutcomeInformation/p:eventOutcome",
+        "fragment_id": "./p:linkingObjectIdentifier[p:linkingObjectIdentifierType='MEDIAHAVEN_ID']/p:linkingObjectIdentifierValue",
+        "external_id": "./p:linkingObjectIdentifier[p:linkingObjectIdentifierType='EXTERNAL_ID']/p:linkingObjectIdentifierValue",
+    }
+
     def __init__(self, element):
         self.xml_element = element
-        self.event_type: str = self._get_event_type()
-        self.event_datetime: str = self._get_event_datetime()
-        self.event_detail: str = self._get_event_detail()
-        self.event_id: str = self._get_event_id()
-        self.event_outcome: str = self._get_event_outcome()
-        self.fragment_id: str = self._get_fragment_id()
-        self.external_id: str = self._get_external_id()
+        self.event_type: str = self._get_xpath_from_event(self.XPATHS["event_type"])
+        self.event_datetime: str = self._get_xpath_from_event(self.XPATHS["event_datetime"])
+        self.event_detail: str = self._get_xpath_from_event(self.XPATHS["event_detail"])
+        self.event_id: str = self._get_xpath_from_event(self.XPATHS["event_id"])
+        self.event_outcome: str = self._get_xpath_from_event(self.XPATHS["event_outcome"])
+        self.fragment_id: str = self._get_xpath_from_event(self.XPATHS["fragment_id"])
+        self.external_id: str = self._get_xpath_from_event(self.XPATHS["external_id"])
         self.is_valid: bool = self._is_valid()
 
-    def _get_event_type(self) -> str:
-        return self.xml_element.xpath(
-            "./p:eventType", namespaces={"p": PREMIS_NAMESPACE}
-        )[0].text
-
-    def _get_event_datetime(self) -> str:
-        return self.xml_element.xpath(
-            "./p:eventDateTime", namespaces={"p": PREMIS_NAMESPACE}
-        )[0].text
-
-    def _get_event_detail(self) -> str:
-        return self.xml_element.xpath(
-            "./p:eventDetail", namespaces={"p": PREMIS_NAMESPACE}
-        )[0].text
-
-    def _get_event_id(self) -> str:
-        return self.xml_element.xpath(
-            "./p:eventIdentifier[p:eventIdentifierType='MEDIAHAVEN_EVENT']/p:eventIdentifierValue",
-            namespaces={"p": PREMIS_NAMESPACE},
-        )[0].text
-
-    def _get_event_outcome(self) -> str:
-        return self.xml_element.xpath(
-            "./p:eventOutcomeInformation/p:eventOutcome",
-            namespaces={"p": PREMIS_NAMESPACE},
-        )[0].text
-
-    def _get_fragment_id(self) -> str:
-        return self.xml_element.xpath(
-            "./p:linkingObjectIdentifier[p:linkingObjectIdentifierType='MEDIAHAVEN_ID']/p:linkingObjectIdentifierValue",
-            namespaces={"p": PREMIS_NAMESPACE},
-        )[0].text
-
-    def _get_external_id(self) -> str:
-        """Parses and returns the EXTERNAL_ID, if absent return an empty string"""
+    def _get_xpath_from_event(self, xpath) -> str:
+        """Parses based on an xpath, returns empty string if absent"""
         try:
             return self.xml_element.xpath(
-                "./p:linkingObjectIdentifier[p:linkingObjectIdentifierType='EXTERNAL_ID']/p:linkingObjectIdentifierValue",
-                namespaces={"p": PREMIS_NAMESPACE},
+                xpath, namespaces={"p": PREMIS_NAMESPACE}
             )[0].text
         except IndexError:
             return ""
@@ -81,9 +57,6 @@ class PremisEvent:
             self.fragment_id):
             return True
         return False
-
-    def to_string(self, pretty=False) -> str:
-        return etree.tostring(events[0], pretty_print=pretty).decode("utf-8")
 
 
 class PremisEvents:

--- a/app/helpers/events_parser.py
+++ b/app/helpers/events_parser.py
@@ -63,10 +63,14 @@ class PremisEvent:
         )[0].text
 
     def _get_external_id(self) -> str:
-        return self.xml_element.xpath(
-            "./p:linkingObjectIdentifier[p:linkingObjectIdentifierType='EXTERNAL_ID']/p:linkingObjectIdentifierValue",
-            namespaces={"p": PREMIS_NAMESPACE},
-        )[0].text
+        """Parses and returns the EXTERNAL_ID, if absent return an empty string"""
+        try:
+            return self.xml_element.xpath(
+                "./p:linkingObjectIdentifier[p:linkingObjectIdentifierType='EXTERNAL_ID']/p:linkingObjectIdentifierValue",
+                namespaces={"p": PREMIS_NAMESPACE},
+            )[0].text
+        except IndexError:
+            return ""
 
     def _is_valid(self):
         """A PremisEvent is valid only if:

--- a/tests/helpers/test_events_parser.py
+++ b/tests/helpers/test_events_parser.py
@@ -9,6 +9,7 @@ from tests.resources import (
         multi_premis_event,
         invalid_premis_event,
         invalid_xml_event,
+        single_event_no_external_id
 )
 from app.helpers.events_parser import (
     PremisEvents,
@@ -26,6 +27,7 @@ def test_single_event():
     assert p.events[0].event_type == "FLOW.ARCHIVED"
     assert p.events[0].event_outcome == "NOK"
     assert p.events[0].event_datetime == "2019-03-30T05:28:40Z"
+    assert p.events[0].external_id == "a1"
     assert p.events[0].is_valid
 
 def test_multi_event():
@@ -60,3 +62,7 @@ def test_invalid_premis_event():
 def test_invalid_xml_event():
     with pytest.raises(XMLSyntaxError) as e:
         p = PremisEvents(invalid_xml_event)
+
+def test_single_event_no_external_id():
+    p = PremisEvents(single_event_no_external_id)
+    assert p.events[0].external_id == ""

--- a/tests/helpers/test_events_parser.py
+++ b/tests/helpers/test_events_parser.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-from lxml.etree import XMLSyntaxError
+from lxml.etree import XMLSyntaxError, fromstring as parse_xml_string
 
 from tests.resources import (
         single_premis_event,
@@ -12,6 +12,7 @@ from tests.resources import (
         single_event_no_external_id
 )
 from app.helpers.events_parser import (
+    PremisEvent,
     PremisEvents,
     InvalidPremisEventException,
 )
@@ -66,3 +67,10 @@ def test_invalid_xml_event():
 def test_single_event_no_external_id():
     p = PremisEvents(single_event_no_external_id)
     assert p.events[0].external_id == ""
+
+def test_get_xpath_from_event():
+    input_xml = "<xml><path>value</path></xml>"
+    tree = parse_xml_string(input_xml)
+    p = PremisEvent(tree)
+    assert p._get_xpath_from_event("no_such_path") == ""
+    assert p._get_xpath_from_event("path") == "value"

--- a/tests/resources/__init__.py
+++ b/tests/resources/__init__.py
@@ -5,3 +5,4 @@ from .premis_events import single_premis_event
 from .premis_events import multi_premis_event
 from .premis_events import invalid_premis_event
 from .premis_events import invalid_xml_event
+from .premis_events import single_event_no_external_id

--- a/tests/resources/premis_events.py
+++ b/tests/resources/premis_events.py
@@ -1,15 +1,21 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import os
 
-with open('./tests/resources/single_premis_event.xml', 'rb') as f:
+folder = os.path.join(os.getcwd(), 'tests', 'resources')
+
+with open(os.path.join(folder, 'single_premis_event.xml'), 'rb') as f:
     single_premis_event = f.read()
 
-with open('./tests/resources/multi_premis_event.xml', 'rb') as f:
+with open(os.path.join(folder, 'multi_premis_event.xml'), 'rb') as f:
     multi_premis_event = f.read()
 
-with open('./tests/resources/invalid_premis_event.xml', 'rb') as f:
+with open(os.path.join(folder, 'invalid_premis_event.xml'), 'rb') as f:
     invalid_premis_event = f.read()
 
-with open('./tests/resources/invalid_xml_event.xml', 'rb') as f:
+with open(os.path.join(folder, 'invalid_xml_event.xml'), 'rb') as f:
     invalid_xml_event = f.read()
+
+with open(os.path.join(folder, 'single_event_no_external_id.xml'), 'rb') as f:
+    single_event_no_external_id = f.read()

--- a/tests/resources/single_event_no_external_id.xml
+++ b/tests/resources/single_event_no_external_id.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<events>
+  <premis:event xmlns:premis="info:lc/xmlns/premis-v2">
+    <premis:eventIdentifier>
+      <premis:eventIdentifierType>MEDIAHAVEN_EVENT</premis:eventIdentifierType>
+      <premis:eventIdentifierValue>111</premis:eventIdentifierValue>
+    </premis:eventIdentifier>
+    <premis:eventType>FLOW.ARCHIVED</premis:eventType>
+    <premis:eventDateTime>2019-03-30T05:28:40Z</premis:eventDateTime>
+    <premis:eventDetail>Ionic Defibulizer</premis:eventDetail>
+    <premis:eventOutcomeInformation>
+      <premis:eventOutcome>NOK</premis:eventOutcome>
+    </premis:eventOutcomeInformation>
+    <premis:linkingAgentIdentifier>
+      <premis:linkingAgentIdentifierType>MEDIAHAVEN_USER</premis:linkingAgentIdentifierType>
+      <premis:linkingAgentIdentifierValue>703a53d2-dc66-4eb2-ab7f-73d5fd228852</premis:linkingAgentIdentifierValue>
+    </premis:linkingAgentIdentifier>
+    <premis:linkingObjectIdentifier>
+      <premis:linkingObjectIdentifierType>MEDIAHAVEN_ID</premis:linkingObjectIdentifierType>
+      <premis:linkingObjectIdentifierValue>a1b2c3</premis:linkingObjectIdentifierValue>
+    </premis:linkingObjectIdentifier>
+  </premis:event>
+</events>


### PR DESCRIPTION
An incoming premis event can be absent of an external ID.
Parsing such an event should not result in a crash. The parsed
external ID in that case should be an empty string.

Also, the filenames in premis_events.py are now OS independent.