### PR TITLE
DEV-2591 Lock usage of MediaHaven client

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For more information on configuring RabbitMQ see [RabbitMQ](#RabbitMQ).
 
 - Git
 - Docker
-- Python 3.6+
+- Python 3.10+
 - Access to the [meemoo PyPi](http://do-prd-mvn-01.do.viaa.be:8081)
 
 ## Usage

--- a/app/app.py
+++ b/app/app.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from typing import Dict
+import threading
 
 from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Request
 from fastapi.responses import PlainTextResponse
@@ -25,6 +26,7 @@ app = FastAPI()
 config = ConfigParser()
 log = logging.get_logger(__name__, config=config)
 _mediahaven_client: MediaHaven = None
+mediahaven_lock = threading.Lock()
 
 
 def _get_fragment_metadata(fragment_id: str, mh_client: MediaHaven) -> Dict[str, str]:
@@ -43,7 +45,8 @@ def _get_fragment_metadata(fragment_id: str, mh_client: MediaHaven) -> Dict[str,
     """
 
     try:
-        fragment = mh_client.records.get(fragment_id)
+        with mediahaven_lock:
+            fragment = mh_client.records.get(fragment_id)
     except MediaHavenException as error:
         if error.status_code == "404":
             log.error(
@@ -145,7 +148,8 @@ def _handle_premis_event(event: PremisEvent, mh_client: MediaHaven):
         )
         # Get the fragment metadata to find the organisation
         try:
-            fragment = mh_client.records.get(event.fragment_id)
+            with mediahaven_lock:
+                fragment = mh_client.records.get(event.fragment_id)
             organisation_name = fragment.Administrative.OrganisationName
         except MediaHavenException as e:
             log.warning(e, fragment_id=event.fragment_id, pid=event.external_id)

--- a/app/app.py
+++ b/app/app.py
@@ -5,7 +5,7 @@ from typing import Dict
 import threading
 
 from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Request
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import PlainTextResponse, JSONResponse
 from lxml.etree import XMLSyntaxError
 from mediahaven import MediaHaven
 from mediahaven.mediahaven import MediaHavenException
@@ -230,7 +230,7 @@ async def handle_event(
     request: Request,
     background_tasks: BackgroundTasks,
     mh_client: MediaHaven = Depends(get_mediahaven_client),
-) -> str:
+) -> JSONResponse:
     # Get and parse the incoming event(s)
     events_xml: bytes = await request.body()
     log.debug(events_xml.decode("utf8"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ pytest-cov==2.8.1
 pika==1.3.2
 mediahaven==0.7.0
 lxml==4.9.3
-fastapi==0.63.0
+fastapi[standard]==0.112.2
 boto3==1.28.4
-uvicorn==0.13.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ viaa-chassis==0.1.3
 pytest==7.2.2
 pytest-cov==2.8.1
 pika==1.3.0
-mediahaven==0.4.3
+mediahaven==0.7.0
 lxml==4.9.3
 fastapi==0.63.0
 boto3==1.28.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 viaa-chassis==0.1.3
 pytest==7.2.2
 pytest-cov==2.8.1
-pika==1.3.0
+pika==1.3.2
 mediahaven==0.7.0
 lxml==4.9.3
 fastapi==0.63.0


### PR DESCRIPTION
When the access token is expired, a new one will be automatically requested
making use of the stored refresh token. You can use this refresh token only
once in order to get a new access token and refresh token. Once used, the
refresh token is expired/invalid.

Incoming PREMIS events are handled in an asynchronous way, in a sense that the
actual processing is defined as a "background task". In other words, if the XML
is valid, a response is returned to the client but the actual operation is done
afterwards, in the background, so that the client doesn't need to wait.

These background tasks are apparently handled in a multi-threaded way. It is
possible that the refresh token is being used multiple times simultaneously
when the access token is expired. An easy fix would be to make use of a
lock when using the MediaHaven client.

Also, update some dependecies:
- Pika to the latest bugfix release
- MediaHaven client to the latest release
- Fastapi to the latest release. The breaking changes should not have any impact.
  Also install the standard fastapi dependencies. This includes uvicorn,
  meaning that the dependency can be removed from requirements.txt.

Furthermore, fix the README with the actual supported Python version as 3.10 is the current development version.